### PR TITLE
Update library paths

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 type apiData struct {

--- a/commands.go
+++ b/commands.go
@@ -31,8 +31,8 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/discordconsole-team/DiscordConsole/PermCalc"
 	"github.com/fatih/color"
-	"github.com/legolord208/gtable"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/gtable"
+	"github.com/jD91mZM2/stdutil"
 )
 
 var mutexCommand sync.Mutex

--- a/commands_navigate.go
+++ b/commands_navigate.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/gtable"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/gtable"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func commandsNavigate(session *discordgo.Session, cmd string, args []string, nargs int, w io.Writer) (returnVal string) {

--- a/commands_query.go
+++ b/commands_query.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func commandsQuery(session *discordgo.Session, cmd string, args []string, nargs int, w io.Writer) (returnVal string) {

--- a/commands_roles.go
+++ b/commands_roles.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/gtable"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/gtable"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func commandsRoles(session *discordgo.Session, cmd string, args []string, nargs int, w io.Writer) (returnVal string) {

--- a/commands_say.go
+++ b/commands_say.go
@@ -29,7 +29,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func commandsSay(session *discordgo.Session, source commandSource, cmd string, args []string, nargs int, w io.Writer) (returnVal string) {

--- a/commands_usermod.go
+++ b/commands_usermod.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func commandsUserMod(session *discordgo.Session, cmd string, args []string, nargs int, w io.Writer) (returnVal string) {

--- a/errorfilter.go
+++ b/errorfilter.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 	"github.com/mattn/go-colorable"
 )
 

--- a/intercept.go
+++ b/intercept.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 func messageCreate(session *discordgo.Session, e *discordgo.MessageCreate) {

--- a/languages.go
+++ b/languages.go
@@ -27,7 +27,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 var errLangCorrupt = errors.New("corrupt language file")

--- a/location.go
+++ b/location.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 type location struct {

--- a/lua.go
+++ b/lua.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Shopify/go-lua"
 	"github.com/bwmarrin/discordgo"
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 type luaEventData struct {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 const autoRunFile = ".autorun"

--- a/music.go
+++ b/music.go
@@ -24,7 +24,7 @@ import (
 	"os"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/legolord208/stdutil"
+	"github.com/jD91mZM2/stdutil"
 )
 
 var vc *discordgo.VoiceConnection


### PR DESCRIPTION
People using the correct paths will currently need to have 2 libraries installed.
Not only that, but anybody can claim the github name "legolord208" since it's just a redirect,
and upload a virus on it. Congratz.
This is why Go library management sucks.